### PR TITLE
Implement CNFGSetVSync in the EGL driver

### DIFF
--- a/CNFGEGLDriver.c
+++ b/CNFGEGLDriver.c
@@ -466,6 +466,11 @@ void CNFGClearFrame()
 	glClear(GL_COLOR_BUFFER_BIT /*| GL_DEPTH_BUFFER_BIT*/);
 }
 
+void CNFGSetVSync( int vson )
+{
+	eglSwapInterval(egl_display, vson);
+}
+
 void CNFGSwapBuffers()
 {
 	FlushRender();


### PR DESCRIPTION
As far as I know, this is all we need to support CNFGSetVSync on Android.