### PR TITLE
Added opengl32, FIXES #22, and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ int main()
 
 Windows compile:
 ```
-C:\tcc\tcc rawdraw.c -Irawdraw -lgdi32 -luser32
+C:\tcc\tcc rawdraw.c -Irawdraw -lopengl32 -lgdi32 -luser32
 ```
 
 Linux compile:

--- a/rawdraw.c
+++ b/rawdraw.c
@@ -7,6 +7,7 @@
 
 #define CNFG3D
 #define CNFG_IMPLEMENTATION
+#define CNFGOGL
 #include "CNFG.h"
 
 
@@ -15,7 +16,7 @@ unsigned long iframeno = 0;
 
 void HandleKey( int keycode, int bDown )
 {
-	if( keycode == 65307 ) exit( 0 );
+	if( keycode == 27 ) exit( 0 );
 	printf( "Key: %d -> %d\n", keycode, bDown );
 }
 


### PR DESCRIPTION
I added opengl32 in the define and edited the README.md command line compile string to reflect this.

I changed the keycode for ESC from 65307 to 27, so when you hit ESC, the running process exits. 65307 read as a key 27 press and release in the terminal, but the program would not exit.

It now exits properly.