### PR TITLE
Replaced references to CNFGFunctions.h with CNFG.h

### DIFF
--- a/CNFGEGLLeanAndMean.c
+++ b/CNFGEGLLeanAndMean.c
@@ -5,7 +5,7 @@
 //NOTE: This is a truly incomplete driver - if no EGL surface is available, it does not support direct buffer rendering.
 //Additionally no input is connected.
 
-#include "CNFGFunctions.h"
+#include "CNFG.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/CNFGOGLEGLDriver.c
+++ b/CNFGOGLEGLDriver.c
@@ -5,7 +5,7 @@
 //NOTE: This is a truly incomplete driver - if no EGL surface is available, it does not support direct buffer rendering.
 //Additionally no input is connected.
 
-#include "CNFGFunctions.h"
+#include "CNFG.h"
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>

--- a/CNFGRasterizer.c
+++ b/CNFGRasterizer.c
@@ -1,7 +1,7 @@
 //Don't call this file yourself.  It is intended to be included in any drivers which want to support the rasterizer plugin.
 
 #ifdef RASTERIZER
-#include "CNFGFunctions.h"
+#include "CNFG.h"
 #include <stdlib.h>
 #include <stdint.h>
 

--- a/attic/CNFGCocoaCGDriver.m
+++ b/attic/CNFGCocoaCGDriver.m
@@ -6,7 +6,7 @@
 
 #define RGB2Color(RGB) (RGB&0xFF)/256., ((RGB>>8)&0xFF)/256., ((RGB>>16)&0xFF)/256. 
 
-#include "CNFGFunctions.h"
+#include "CNFG.h"
 
 id app_menubar, app_appMenuItem, app_appMenu, app_appName, app_quitMenuItem, app_quitTitle, app_quitMenuItem, app_window;
 NSView *app_imageView;

--- a/examples/fontsize.c
+++ b/examples/fontsize.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "../CNFGFunctions.h"
+#include "../CNFG.h"
 #include "../os_generic.h"
 #include "../CNFG3D.h"
 

--- a/osdtest.c
+++ b/osdtest.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "CNFGFunctions.h"
+#include "CNFG.h"
 #include "os_generic.h"
 #include "CNFG3D.h"
 


### PR DESCRIPTION
In https://github.com/cntools/rawdraw/commit/57acb10cd9876d95342d80e8775d14a295174a80 you removed `CNFGFunctions.h` but you didn't fix all the references. This broke swadgemu when I tried to update it