### PR TITLE
Removed ontop from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,6 @@ osdtest : osdtest.c CNFG.c
 vulkantest : rawdraw.c CNFG.c
 	gcc -o $@ $^ -lX11 -lpthread -lm -O3 -lvulkan
 
-ontop : ontop.c CNFG.c
-	gcc -o $@ $^ -lpthread -lX11 -lm -lXinerama -lXext -lGL
-
 rawdraw_mac : rawdraw.c CNFG.c
 	gcc -o $@ $^ -x objective-c -framework Cocoa -framework OpenGL -lm -lpthread -DCNFGRASTERIZER
 
@@ -53,5 +50,5 @@ ogltest.exe : ogltest.c CNFG.c
 	$(MINGW32)gcc -o $@ $^ -lgdi32 -lkernel32 -lopengl32 -DCNFGOGL
 
 clean : 
-	rm -rf *.o *~ rawdraw.exe rawdraw ontop rawdraw_ogl rawdraw_mac rawdraw_mac_soft rawdraw_mac_cg rawdraw_mac_ogl ogltest ogltest.exe rawdraw_egl
+	rm -rf *.o *~ rawdraw.exe rawdraw rawdraw_ogl rawdraw_mac rawdraw_mac_soft rawdraw_mac_cg rawdraw_mac_ogl ogltest ogltest.exe rawdraw_egl
 


### PR DESCRIPTION
Removed ontop from Makefile, because ontop.c is not available in this repository