### PR TITLE
XDriver: Fix CNFGTackPoly only drawing triangles

### DIFF
--- a/CNFGXDriver.c
+++ b/CNFGXDriver.c
@@ -587,7 +587,7 @@ void AGLF(CNFGTackRectangle)( short x1, short y1, short x2, short y2 )
 
 void AGLF(CNFGTackPoly)( RDPoint * points, int verts )
 {
-	XFillPolygon(CNFGDisplay, CNFGPixmap, CNFGGC, (XPoint *)points, 3, Convex, CoordModeOrigin );
+	XFillPolygon(CNFGDisplay, CNFGPixmap, CNFGGC, (XPoint *)points, verts, Convex, CoordModeOrigin );
 }
 
 void AGLF(CNFGInternalResize)( short x, short y ) { }


### PR DESCRIPTION
As discussed in https://github.com/cntools/rawdraw/issues/50