### PR TITLE
A user can check for CNFG_X11_EXPOSE to know the window needs to be…

### DIFF
--- a/CNFG.h
+++ b/CNFG.h
@@ -209,6 +209,7 @@ extern uint32_t CNFGVertDataC[CNFG_BATCH];
 #define CNFG_KEY_BOTTOM_ARROW 65364
 #define CNFG_KEY_ESCAPE 65307
 #define CNFG_KEY_ENTER 65293
+#define CNFG_X11_EXPOSE 0xff00 //65280
 
 #endif
 

--- a/CNFGXDriver.c
+++ b/CNFGXDriver.c
@@ -383,6 +383,7 @@ int CNFGHandleInput()
 			CNFGPixmap = XCreatePixmap( CNFGDisplay, CNFGWindow, CNFGWinAtt.width, CNFGWinAtt.height, CNFGWinAtt.depth );
 			if( CNFGGC ) XFreeGC( CNFGDisplay, CNFGGC );
 			CNFGGC = XCreateGC(CNFGDisplay, CNFGPixmap, 0, 0);
+			HandleKey( CNFG_X11_EXPOSE, 0 );
 			break;
 		case KeyRelease:
 		{


### PR DESCRIPTION
…repainted. In case they don't want to do that in the main loop.