### PR TITLE
cleanup in image blitting functions

### DIFF
--- a/CNFGFunctions.c
+++ b/CNFGFunctions.c
@@ -858,12 +858,12 @@ void CNFGBlitTex( unsigned int tex, int x, int y, int w, int h )
 	const float verts[] = {
 		0,0, w,0, w,h,
 		0,0, w,h, 0,h, };
-	static const uint8_t colors[] = {
+	static const uint8_t tex_verts[] = {
 		0,0,   255,0,  255,255,
 		0,0,  255,255, 0,255 };
 
 	CNFGglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, verts);
-	CNFGglVertexAttribPointer(1, 2, GL_UNSIGNED_BYTE, GL_TRUE, 0, colors);
+	CNFGglVertexAttribPointer(1, 2, GL_UNSIGNED_BYTE, GL_TRUE, 0, tex_verts);
 
 	glDrawArrays( GL_TRIANGLES, 0, 6);
 }
@@ -875,16 +875,6 @@ void CNFGBlitImageInternal( uint32_t * data, int x, int y, int w, int h )
 void CNFGBlitImage( uint32_t * data, int x, int y, int w, int h )
 #endif
 {
-	if( w <= 0 || h <= 0 ) return;
-
-	CNFGFlushRender();
-
-	CNFGglUseProgram( gRDBlitProg );
-	CNFGglUniform4f( gRDBlitProgUX,
-		1.f/gRDLastResizeW, -1.f/gRDLastResizeH,
-		-0.5f+x/(float)gRDLastResizeW, 0.5f-y/(float)gRDLastResizeH );
-	CNFGglUniform1i( gRDBlitProgUT, 0 );
-
 	glEnable( GL_TEXTURE_2D );
 	CNFGglActiveTexture( 0 );
 	glBindTexture( GL_TEXTURE_2D, gRDBlitProgTex );
@@ -896,16 +886,7 @@ void CNFGBlitImage( uint32_t * data, int x, int y, int w, int h )
 	glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0,  GL_RGBA,
 		GL_UNSIGNED_BYTE, data );
 
-	const float verts[] = {
-		0,0, w,0, w,h,
-		0,0, w,h, 0,h, };
-	static const uint8_t colors[] = {
-		0,0,   255,0,  255,255,
-		0,0,  255,255, 0,255 };
-
-	CNFGglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, verts);
-	CNFGglVertexAttribPointer(1, 2, GL_UNSIGNED_BYTE, GL_TRUE, 0, colors);
-	glDrawArrays( GL_TRIANGLES, 0, 6);
+	CNFGBlitTex( gRDBlitProgTex, x, y, w, h );
 }
 
 void CNFGUpdateScreenWithBitmap( uint32_t * data, int w, int h )


### PR DESCRIPTION
The texture vertex array was named colors, even though it has nothing to do with color.

I also replaced the drawing part of `CNFGBlitImage` with a call to `CNFGBlitTex`.