### PR TITLE
Fix exit button not working in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,12 @@ void HandleDestroy() { }
 int main()
 {
 	CNFGSetup( "Example App", 1024, 768 );
-	while(1)
+	while(CNFGHandleInput())
 	{
 		CNFGBGColor = 0x000080ff; //Dark Blue Background
 
 		short w, h;
 		CNFGClearFrame();
-		CNFGHandleInput();
 		CNFGGetDimensions( &w, &h );
 
 		//Change color to white.

--- a/examples/fontsize.c
+++ b/examples/fontsize.c
@@ -47,8 +47,7 @@ int main()
 
 
 
-	while ( 1 ) {
-		CNFGHandleInput();
+	while (CNFGHandleInput()) {
 		CNFGClearFrame();
 		CNFGColor( 0xffffff );
 		for( i = 1; i < 5; i++ )

--- a/ogltest.c
+++ b/ogltest.c
@@ -28,10 +28,9 @@ int main()
 	int frameno = 0;
 	CNFGSetup( "Test", 100, 100 );
 
-	while(1)
+	while(CNFGHandleInput())
 	{
 		CNFGClearFrame();
-		CNFGHandleInput();
 
 		glRotatef( frameno/100.0, 0, 0, 1);
 

--- a/osdtest.c
+++ b/osdtest.c
@@ -50,14 +50,12 @@ int main()
 	CNFGPrepareForTransparency();
 	CNFGSetupFullscreen( "Test Bench", 0 );
 
-	while(1)
+	while(CNFGHandleInput())
 	{
 		int i, pos;
 		float f;
 		iframeno++;
 		RDPoint pto[3];
-
-		CNFGHandleInput();
 
 		CNFGClearFrame();
 		CNFGColor( 0xFFFFFF );

--- a/rawdraw.c
+++ b/rawdraw.c
@@ -183,14 +183,12 @@ int main()
 		Heightmap[x+y*HMX] = tdPerlin2D( x, y )*8.;
 	}
 
-	while(1)
+	while(CNFGHandleInput())
 	{
 		int i, pos;
 		float f;
 		iframeno++;
 		RDPoint pto[3];
-
-		CNFGHandleInput();
 
 		CNFGClearFrame();
 		CNFGColor( 0xFFFFFFFF );

--- a/wasm/rawdraw.c
+++ b/wasm/rawdraw.c
@@ -81,7 +81,7 @@ int __attribute__((export_name("main"))) main()
 int __attribute__((export_name("loop"))) loop()
 {
 #else
-while(1)
+while(CNFGHandleInput())
 #endif
 	{
 		int i, pos;
@@ -91,7 +91,7 @@ while(1)
 
 		//Normally this would invoke callbacks, but
 		//at least currently, we do that out-of-band.
-		CNFGHandleInput();
+		//CNFGHandleInput();
 
 
 		CNFGClearFrame();


### PR DESCRIPTION
This only applies to examples. Tested on Linux. Applied the fix every example even if the platform doesn't support it.