### PR TITLE
Fix HandleInput instantly closing under XWayland

### DIFF
--- a/CNFGXDriver.c
+++ b/CNFGXDriver.c
@@ -46,6 +46,7 @@ XClassHint *CNFGClassHint;
 char * wm_res_name = 0;
 char * wm_res_class = 0;
 Display *CNFGDisplay;
+Atom CFNGWMDeleteWindow;
 Window CNFGWindow;
 int CNFGWindowInvisible;
 Pixmap CNFGPixmap;
@@ -326,6 +327,7 @@ void CNFGTearDown()
 	CNFGDisplay = NULL;
 	CNFGWindowGC = CNFGGC = NULL;
 	CNFGClassHint = NULL;
+	CFNGWMDeleteWindow = None;
 }
 
 int CNFGSetupWMClass( const char * WindowName, int w, int h , char * wm_res_name_ , char * wm_res_class_ )
@@ -371,8 +373,8 @@ int CNFGSetup( const char * WindowName, int w, int h )
 	InternalLinkScreenAndGo( WindowName );
 
 //Not sure of the purpose of this code - if it's still commented out after 2019-12-31 and no one knows why, please delete it.
-	Atom WM_DELETE_WINDOW = XInternAtom( CNFGDisplay, "WM_DELETE_WINDOW", False );
-	XSetWMProtocols( CNFGDisplay, CNFGWindow, &WM_DELETE_WINDOW, 1 );
+	CFNGWMDeleteWindow = XInternAtom( CNFGDisplay, "WM_DELETE_WINDOW", False );
+	XSetWMProtocols( CNFGDisplay, CNFGWindow, &CFNGWMDeleteWindow, 1 );
 
 #ifdef CNFGOGL
 	glXMakeCurrent( CNFGDisplay, CNFGWindow, CNFGCtx );
@@ -439,8 +441,8 @@ int CNFGHandleInput()
 			HandleMotion( report.xmotion.x, report.xmotion.y, ButtonsDown>>1 );
 			break;
 		case ClientMessage:
-			// Only subscribed to WM_DELETE_WINDOW, so return 0 to let user know of window exit
-			return 0;
+			if ( report.xclient.data.l[0] == CFNGWMDeleteWindow )
+				return 0;
 			break;
 		default:
 			break;


### PR DESCRIPTION
On XWayland, the Wayland surface resource id is delivered via a ClientMessage which does not need to be subscribed to.

Previously we were treating any ClientMessage as an instant 'close window' and not checking it because we assumed that it was always that atom.

This was problematic as the XWayland surface resource id message would make us trigger that instant close path.

Instead, change the code such that we check the associated atom of the client message matches the delete message event.