### PR TITLE
Free XVisualInfo after creating Context

### DIFF
--- a/CNFGXDriver.c
+++ b/CNFGXDriver.c
@@ -89,6 +89,7 @@ void CNFGGLXSetup( )
 	CNFGVisualID = vis->visualid;
 	CNFGDepth = vis->depth;
 	CNFGCtx = glXCreateContext( CNFGDisplay, vis, NULL, True );
+	XFree( vis );
 }
 
 #endif


### PR DESCRIPTION
My project builds with `-fsanitize=address` and highlighted that `vis` is never freed