### PR TITLE
Stop Logcat spam

### DIFF
--- a/CNFG.h
+++ b/CNFG.h
@@ -133,6 +133,9 @@ void HandleKey( int keycode, int bDown );
 void HandleButton( int x, int y, int button, int bDown );
 void HandleMotion( int x, int y, int mask );
 void HandleDestroy();
+#if defined( ANDROID )
+void HandleWindowTermination();
+#endif
 
 //Internal function for resizing rasterizer for rasterizer-mode.
 void CNFGInternalResize( short x, short y ); //don't call this.

--- a/CNFGEGLDriver.c
+++ b/CNFGEGLDriver.c
@@ -160,6 +160,7 @@ static short iLastInternalW, iLastInternalH;
 
 void CNFGSwapBuffers()
 {
+	if ( egl_display == EGL_NO_DISPLAY ) return;
 	CNFGFlushRender();
 	eglSwapBuffers(egl_display, egl_surface);
 #ifdef ANDROID
@@ -486,11 +487,25 @@ void handle_cmd(struct android_app* app, int32_t cmd)
 			HandleResume();
 		}
 		break;
-	//case APP_CMD_TERM_WINDOW:
+	case APP_CMD_TERM_WINDOW:
 		//This gets called initially when you click "back"
 		//This also gets called when you are brought into standby.
 		//Not sure why - callbacks here seem to break stuff.
-	//	break;
+		if( egl_display != EGL_NO_DISPLAY ) {
+			eglMakeCurrent( egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT );
+			if( egl_context != EGL_NO_CONTEXT ) {
+				eglDestroyContext( egl_display, egl_context );
+			}
+			if( egl_surface != EGL_NO_SURFACE ) {
+				eglDestroySurface( egl_display, egl_surface );
+			}
+			eglTerminate( egl_display );
+		}
+		egl_context = EGL_NO_CONTEXT;
+		egl_surface = EGL_NO_SURFACE;
+		egl_display = EGL_NO_DISPLAY;
+		HandleWindowTermination();
+		break;
 
 	case APP_CMD_PAUSE:
 		HandleSuspend();


### PR DESCRIPTION
As far as I can tell, the logcat spam (https://github.com/cnlohr/rawdrawandroid/issues/21) on Android is caused by calling `eglSwapBuffers` when the surface is invalid.

This change is not _required_ - I think just bubbling up `WindowTermination` and asking the user to not call `CNFGSwapBuffers` on a terminated window is sufficient to stop the spam.

The changes in this PR bubble up the event, but also guard against calls to `CNFGSwapBuffers` when the window is in an invalid state.