### PR TITLE
Use more environment variables for OS detection

### DIFF
--- a/CNFG.c
+++ b/CNFG.c
@@ -10,11 +10,16 @@ int CNFGLastScancode = 0;
 #include "CNFGHTTP.c"
 #elif defined( __wasm__ )
 #include "CNFGWASMDriver.c"
-#elif defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#elif defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 #include "CNFGWinDriver.c"
 #elif defined( EGL_LEAN_AND_MEAN )
 #include "CNFGEGLLeanAndMean.c"
-#elif defined( __android__ ) || defined( ANDROID )
+#elif defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 #include "CNFGEGLDriver.c"
 #else
 #include "CNFGXDriver.c"

--- a/CNFG.h
+++ b/CNFG.h
@@ -51,7 +51,7 @@ Usually tested combinations:
 #include <stdint.h>
 
 //Some per-platform logic.
-#if defined( ANDROID ) || defined( __android__ )
+#if defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 	#define CNFGOGL
 #endif
 
@@ -59,7 +59,7 @@ Usually tested combinations:
 
 	#define CNFG_BATCH 8192 //131,072 bytes.
 
-	#if defined( ANDROID ) || defined( __android__ ) || defined( __wasm__ ) || defined( EGL_LEAN_AND_MEAN )
+	#if defined(__ANDROID__) || defined(__android__) || defined(ANDROID) || defined( __wasm__ ) || defined( EGL_LEAN_AND_MEAN )
 		#define CNFGEWGL //EGL or WebGL
 	#else
 		#define CNFGDESKTOPGL
@@ -191,7 +191,12 @@ extern uint32_t CNFGVertDataC[CNFG_BATCH];
 #endif
 
 
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 
 #define CNFG_KEY_BACKSPACE 0x08
 #define CNFG_KEY_TAB 0x09
@@ -271,7 +276,7 @@ extern uint32_t CNFGVertDataC[CNFG_BATCH];
 #define CNFG_KEY_RIGHT_ALT 0xA5
 
 #elif defined( EGL_LEAN_AND_MEAN ) // doesn't have any keys
-#elif defined( __android__ ) || defined( ANDROID ) // ^
+#elif defined(__ANDROID__) || defined(__android__) || defined(ANDROID) // ^
 #elif defined( __wasm__ )
 
 #define CNFG_KEY_BACKSPACE 8
@@ -518,7 +523,7 @@ extern const unsigned short RawdrawFontCharMap[256];
 #endif
 
 
-#if defined( ANDROID ) || defined( __android__ )
+#if defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 #include "CNFGAndroid.h"
 #endif
 

--- a/CNFGEGLDriver.c
+++ b/CNFGEGLDriver.c
@@ -23,7 +23,7 @@
  */
 
 
-#if defined( __android__ ) && !defined( ANDROID )
+#if (defined(__ANDROID__) || defined(__android__)) && !defined(ANDROID)
 #define ANDROID
 #endif
 

--- a/CNFGFunctions.c
+++ b/CNFGFunctions.c
@@ -477,14 +477,24 @@ void	CNFGSetLineWidth( short width )
 #define LGLchar GLchar
 #endif
 
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 #define CNFGOGL_NEED_EXTENSION
 #include <GL/gl.h>
 #endif
 
 #ifdef  CNFGOGL_NEED_EXTENSION
 // If we are going to be defining our own function pointer call
-	#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+	#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 	// Make sure to use __stdcall on Windows
 		#define CHEWTYPEDEF( ret, name, rv, paramcall, ... ) \
 			typedef ret (__stdcall *CNFGTYPE##name)( __VA_ARGS__ ); \
@@ -557,7 +567,12 @@ CHEWTYPEDEF( void, glActiveTexture, , (texture), GLenum texture )
 #endif
 
 #ifdef CNFGOGL_NEED_EXTENSION
-#if defined( WIN32 ) || defined( WINDOWS ) || defined( WIN64 )
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 
 //From https://www.khronos.org/opengl/wiki/Load_OpenGL_Functions
 void * CNFGGetProcAddress(const char *name)

--- a/CNFGHTTP.c
+++ b/CNFGHTTP.c
@@ -872,7 +872,12 @@ uint8_t WSPOPMASK()
 
 
 
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #include <winsock2.h>
 #define socklen_t uint32_t
@@ -1033,7 +1038,12 @@ int TickHTTP()
 	{
 		static double last;
 		double now;
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 		static LARGE_INTEGER lpf;
 		LARGE_INTEGER li;
 
@@ -1093,7 +1103,12 @@ int TickHTTP()
 			memset( &tin, 0, addrlen );
 			int tsocket = accept( serverSocket, (struct sockaddr *)&tin, &addrlen );
 
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 			struct linger lx;
 			lx.l_onoff = 1;
 			lx.l_linger = 0;
@@ -1182,7 +1197,12 @@ int TickHTTP()
 
 int RunHTTP( int port )
 {
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 {
     WORD wVersionRequested;
     WSADATA wsaData;
@@ -1212,7 +1232,12 @@ int RunHTTP( int port )
 	}
 
 	//Disable SO_LINGER (Well, enable it but turn it way down)
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 	struct linger lx;
 	lx.l_onoff = 1;
 	lx.l_linger = 0;

--- a/CNFGRasterizer.c
+++ b/CNFGRasterizer.c
@@ -304,12 +304,17 @@ void CNFGBlitImage( uint32_t * data, int x, int y, int w, int h )
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>24)&0xff) * onemalfa + 128)>>8)<<24;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>16)&0xff) * onemalfa + 128)>>8)<<16;
 				newv |= ((((newm>>8)&0xff) * alfa + ((oldm>>8)&0xff) * onemalfa + 128)>>8)<<8;
-#elif defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#elif defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 				uint32_t newv = 255UL<<24; //Alpha, then RGB
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>16)&0xff) * onemalfa + 128)>>8)<<16;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>8)&0xff) * onemalfa + 128)>>8)<<8;
 				newv |= ((((newm>>8)&0xff) * alfa + ((oldm>>0)&0xff) * onemalfa + 128)>>8)<<0;
-#elif defined( ANDROID ) || defined( __android__ )
+#elif defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 				uint32_t newv = 255<<16; //Alpha, then RGB
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>24)&0xff) * onemalfa + 128)>>8)<<24;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>0)&0xff) * onemalfa + 128)>>8)<<0;

--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ Rawdraw is a very disjoint set of configurations
 
 CNFG Configuration options include:
 * `CNFG_IMPLEMENTATION` = Include code for implementation.
-* `__android__` = build Android port
-* `WINDOWS`, `WIN32`, `WIN64` = Windows build
+* `__ANDROID__`, `__android__`, `ANDROID` = build Android port
+* `WINDOWS`, `__WINDOWS__`, `_WINDOWS`, `WIN32`, `WIN64`, `_WIN32`, `_WIN64`, `__WIN32__`, `__CYGWIN__`, `__MINGW32__`, `__MINGW64__`, `__TOS_WIN__`, `_MSC_VER` = Windows build
 * `CNFGOGL` = Make underlying functions use OpenGL if possible.
 * `CNFGRASTERIZER` = Make the underlying graphics engine rasterized functions (software rendering)
 * `CNFG3D` = Include CNFG3D with this rawdraw build.  This provides *rasterized* graphics functions.  Only use this option with the rasterizer.

--- a/chew.c
+++ b/chew.c
@@ -1,4 +1,9 @@
-#if defined( WIN32 ) || defined( WINDOWS ) || defined( WIN64 )
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 #include <windows.h>
 #else
 #include <dlfcn.h>
@@ -39,7 +44,12 @@ void ** syms[] = {
 	#include "chew.h"
 };
 
-#if defined( WIN32 ) || defined( WINDOWS ) || defined( WIN64 )
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 
 //From https://www.khronos.org/opengl/wiki/Load_OpenGL_Functions
 void * chewGetProcAddress(const char *name)

--- a/chew.h
+++ b/chew.h
@@ -3,7 +3,12 @@
 
 #ifndef TABLEONLY
 
-#if defined( WINDOWS ) || defined( _WINDOWS ) || defined( WIN32 ) || defined( WIN64 )
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 #ifdef __TINYC__
 #define GLsizeiptr intptr_t
 #define GLintptr   intptr_t
@@ -54,7 +59,12 @@ typedef ret (STDCALL *usename##_t)( __VA_ARGS__ );	\
 chew_FUN_EXPORT usename##_t	usename##fnptr; \
 chew_FUN_EXPORT ret usename( __VA_ARGS__ );
 
-#if defined( __TINYC__ ) && ( defined( WINDOWS ) || defined( _WINDOWS ) || defined( WIN32 ) || defined( WIN64 ) )
+#if defined( __TINYC__ ) && ( #if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                                                   || defined(WIN32)       || defined(WIN64) \
+                                                   || defined(_WIN32)      || defined(_WIN64) \
+                                                   || defined(__WIN32__)   || defined(__CYGWIN__) \
+                                                   || defined(__MINGW32__) || defined(__MINGW64__) \
+                                                   || defined(__TOS_WIN__) || defined(_MSC_VER) )
 #undef GLchar
 #define GLchar char
 #undef GLDEBUGPROC

--- a/os_generic.h
+++ b/os_generic.h
@@ -133,7 +133,12 @@ OSG_PREFIX void OGSetTLS( og_tls_t key, void * data );
 
 #ifndef OSG_NO_IMPLEMENTATION
 
-#if defined( WIN32 ) || defined (WINDOWS) || defined( _WIN32)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 #define USE_WINDOWS
 #endif
 

--- a/rawdraw_sf.h
+++ b/rawdraw_sf.h
@@ -53,7 +53,7 @@ Usually tested combinations:
 #include <stdint.h>
 
 //Some per-platform logic.
-#if defined( ANDROID ) || defined( __android__ )
+#if defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 	#define CNFGOGL
 #endif
 
@@ -61,7 +61,7 @@ Usually tested combinations:
 
 	#define CNFG_BATCH 8192 //131,072 bytes.
 
-	#if defined( ANDROID ) || defined( __android__ ) || defined( __wasm__ ) || defined( EGL_LEAN_AND_MEAN )
+	#if defined(__ANDROID__) || defined(__android__) || defined(ANDROID) || defined( __wasm__ ) || defined( EGL_LEAN_AND_MEAN )
 		#define CNFGEWGL //EGL or WebGL
 	#else
 		#define CNFGDESKTOPGL
@@ -193,7 +193,12 @@ extern uint32_t CNFGVertDataC[CNFG_BATCH];
 #endif
 
 
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 
 #define CNFG_KEY_BACKSPACE 0x08
 #define CNFG_KEY_TAB 0x09
@@ -273,7 +278,7 @@ extern uint32_t CNFGVertDataC[CNFG_BATCH];
 #define CNFG_KEY_RIGHT_ALT 0xA5
 
 #elif defined( EGL_LEAN_AND_MEAN ) // doesn't have any keys
-#elif defined( __android__ ) || defined( ANDROID ) // ^
+#elif defined(__ANDROID__) || defined(__android__) || defined(ANDROID) // ^
 #elif defined( __wasm__ )
 
 #define CNFG_KEY_BACKSPACE 8
@@ -520,7 +525,7 @@ extern const unsigned short RawdrawFontCharMap[256];
 #endif
 
 
-#if defined( ANDROID ) || defined( __android__ )
+#if defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 #ifndef _CNFG_ANDROID_H
 #define _CNFG_ANDROID_H
 
@@ -575,7 +580,7 @@ void HandleSuspend();
 
 // For debugging:
 
-#if defined( ANDROID ) && !defined( __cplusplus )
+#if (defined(__ANDROID__) || defined(__android__) || defined(ANDROID)) && !defined( __cplusplus )
 
 #include <jni.h>
 
@@ -1624,7 +1629,12 @@ uint8_t WSPOPMASK()
 
 
 
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #include <winsock2.h>
 #define socklen_t uint32_t
@@ -1785,7 +1795,12 @@ int TickHTTP()
 	{
 		static double last;
 		double now;
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 		static LARGE_INTEGER lpf;
 		LARGE_INTEGER li;
 
@@ -1845,7 +1860,12 @@ int TickHTTP()
 			memset( &tin, 0, addrlen );
 			int tsocket = accept( serverSocket, (struct sockaddr *)&tin, &addrlen );
 
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 			struct linger lx;
 			lx.l_onoff = 1;
 			lx.l_linger = 0;
@@ -1934,7 +1954,12 @@ int TickHTTP()
 
 int RunHTTP( int port )
 {
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 {
     WORD wVersionRequested;
     WSADATA wsaData;
@@ -1964,7 +1989,12 @@ int RunHTTP( int port )
 	}
 
 	//Disable SO_LINGER (Well, enable it but turn it way down)
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 	struct linger lx;
 	lx.l_onoff = 1;
 	lx.l_linger = 0;
@@ -3299,12 +3329,17 @@ void CNFGBlitImage( uint32_t * data, int x, int y, int w, int h )
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>24)&0xff) * onemalfa + 128)>>8)<<24;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>16)&0xff) * onemalfa + 128)>>8)<<16;
 				newv |= ((((newm>>8)&0xff) * alfa + ((oldm>>8)&0xff) * onemalfa + 128)>>8)<<8;
-#elif defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#elif defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                       || defined(WIN32)       || defined(WIN64) \
+                       || defined(_WIN32)      || defined(_WIN64) \
+                       || defined(__WIN32__)   || defined(__CYGWIN__) \
+                       || defined(__MINGW32__) || defined(__MINGW64__) \
+                       || defined(__TOS_WIN__) || defined(_MSC_VER)
 				uint32_t newv = 255UL<<24; //Alpha, then RGB
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>16)&0xff) * onemalfa + 128)>>8)<<16;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>8)&0xff) * onemalfa + 128)>>8)<<8;
 				newv |= ((((newm>>8)&0xff) * alfa + ((oldm>>0)&0xff) * onemalfa + 128)>>8)<<0;
-#elif defined( ANDROID ) || defined( __android__ )
+#elif defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 				uint32_t newv = 255<<16; //Alpha, then RGB
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>24)&0xff) * onemalfa + 128)>>8)<<24;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>0)&0xff) * onemalfa + 128)>>8)<<0;
@@ -3357,7 +3392,12 @@ void CNFGHandleInput()
 
 #endif
 
-#elif defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#elif defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                       || defined(WIN32)       || defined(WIN64) \
+                       || defined(_WIN32)      || defined(_WIN64) \
+                       || defined(__WIN32__)   || defined(__CYGWIN__) \
+                       || defined(__MINGW32__) || defined(__MINGW64__) \
+                       || defined(__TOS_WIN__) || defined(_MSC_VER)
 //Copyright (c) 2011-2019 <>< Charles Lohr - Under the MIT/x11 or NewBSD License you choose.
 //Portion from: http://en.wikibooks.org/wiki/Windows_Programming/Window_Creation
 
@@ -3697,12 +3737,17 @@ void CNFGBlitImage( uint32_t * data, int x, int y, int w, int h )
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>24)&0xff) * onemalfa + 128)>>8)<<24;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>16)&0xff) * onemalfa + 128)>>8)<<16;
 				newv |= ((((newm>>8)&0xff) * alfa + ((oldm>>8)&0xff) * onemalfa + 128)>>8)<<8;
-#elif defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#elif defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                       || defined(WIN32)       || defined(WIN64) \
+                       || defined(_WIN32)      || defined(_WIN64) \
+                       || defined(__WIN32__)   || defined(__CYGWIN__) \
+                       || defined(__MINGW32__) || defined(__MINGW64__) \
+                       || defined(__TOS_WIN__) || defined(_MSC_VER)
 				uint32_t newv = 255UL<<24; //Alpha, then RGB
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>16)&0xff) * onemalfa + 128)>>8)<<16;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>8)&0xff) * onemalfa + 128)>>8)<<8;
 				newv |= ((((newm>>8)&0xff) * alfa + ((oldm>>0)&0xff) * onemalfa + 128)>>8)<<0;
-#elif defined( ANDROID ) || defined( __android__ )
+#elif defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 				uint32_t newv = 255<<16; //Alpha, then RGB
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>24)&0xff) * onemalfa + 128)>>8)<<24;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>0)&0xff) * onemalfa + 128)>>8)<<0;
@@ -4470,7 +4515,7 @@ void CNFGSwapBuffers()
 }
 
 
-#elif defined( __android__ ) || defined( ANDROID )
+#elif defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 /*
  * Copyright (c) 2011-2013 Luc Verhaegen <libv@skynet.be>
  * Copyright (c) 2018-2020 <>< Charles Lohr
@@ -4496,7 +4541,7 @@ void CNFGSwapBuffers()
  */
 
 
-#if defined( __android__ ) && !defined( ANDROID )
+#if (defined(__ANDROID__) || defined(__android__)) && !defined( ANDROID )
 #define ANDROID
 #endif
 
@@ -4793,7 +4838,7 @@ int android_sdk_version;
 		unsigned int format; /* extra format information in case rgbal is not enough, especially for YUV formats */
 	} fbdev_pixmap;
 
-#if defined( ANDROID )
+#ifdef ANDROID
 EGLNativeWindowType native_window;
 #else
 struct fbdev_window native_window;
@@ -6406,12 +6451,17 @@ void CNFGBlitImage( uint32_t * data, int x, int y, int w, int h )
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>24)&0xff) * onemalfa + 128)>>8)<<24;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>16)&0xff) * onemalfa + 128)>>8)<<16;
 				newv |= ((((newm>>8)&0xff) * alfa + ((oldm>>8)&0xff) * onemalfa + 128)>>8)<<8;
-#elif defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#elif defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                       || defined(WIN32)       || defined(WIN64) \
+                       || defined(_WIN32)      || defined(_WIN64) \
+                       || defined(__WIN32__)   || defined(__CYGWIN__) \
+                       || defined(__MINGW32__) || defined(__MINGW64__) \
+                       || defined(__TOS_WIN__) || defined(_MSC_VER)
 				uint32_t newv = 255UL<<24; //Alpha, then RGB
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>16)&0xff) * onemalfa + 128)>>8)<<16;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>8)&0xff) * onemalfa + 128)>>8)<<8;
 				newv |= ((((newm>>8)&0xff) * alfa + ((oldm>>0)&0xff) * onemalfa + 128)>>8)<<0;
-#elif defined( ANDROID ) || defined( __android__ )
+#elif defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 				uint32_t newv = 255<<16; //Alpha, then RGB
 				newv |= ((((newm>>24)&0xff) * alfa + ((oldm>>24)&0xff) * onemalfa + 128)>>8)<<24;
 				newv |= ((((newm>>16)&0xff) * alfa + ((oldm>>0)&0xff) * onemalfa + 128)>>8)<<0;
@@ -7002,14 +7052,24 @@ void	CNFGSetLineWidth( short width )
 #define LGLchar GLchar
 #endif
 
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 #define CNFGOGL_NEED_EXTENSION
 #include <GL/gl.h>
 #endif
 
 #ifdef  CNFGOGL_NEED_EXTENSION
 // If we are going to be defining our own function pointer call
-	#if defined(WINDOWS) || defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN64)
+	#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                         || defined(WIN32)       || defined(WIN64) \
+                         || defined(_WIN32)      || defined(_WIN64) \
+                         || defined(__WIN32__)   || defined(__CYGWIN__) \
+                         || defined(__MINGW32__) || defined(__MINGW64__) \
+                         || defined(__TOS_WIN__) || defined(_MSC_VER)
 	// Make sure to use __stdcall on Windows
 		#define CHEWTYPEDEF( ret, name, rv, paramcall, ... ) \
 			typedef ret (__stdcall *CNFGTYPE##name)( __VA_ARGS__ ); \
@@ -7082,7 +7142,12 @@ CHEWTYPEDEF( void, glActiveTexture, , (texture), GLenum texture )
 #endif
 
 #ifdef CNFGOGL_NEED_EXTENSION
-#if defined( WIN32 ) || defined( WINDOWS ) || defined( WIN64 )
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                       || defined(WIN32)       || defined(WIN64) \
+                       || defined(_WIN32)      || defined(_WIN64) \
+                       || defined(__WIN32__)   || defined(__CYGWIN__) \
+                       || defined(__MINGW32__) || defined(__MINGW64__) \
+                       || defined(__TOS_WIN__) || defined(_MSC_VER)
 
 //From https://www.khronos.org/opengl/wiki/Load_OpenGL_Functions
 void * CNFGGetProcAddress(const char *name)


### PR DESCRIPTION
I replaced a ton of preprocessor OS detections with more robust ones. However, I didn't replace all of them, especially where it looked like the author was intentionally not using all possible environment variable names (that they knew of) to detect a certain OS.

As a warning, I've only tested this in a Windows Cygwin environment (by compiling the [Swadge repo](https://github.com/AEFeinstein/Super-2024-Swadge-FW)) so other environments and OSes still need to be tested.