### PR TITLE
Remove references to malloc.h

### DIFF
--- a/CNFGFunctions.c
+++ b/CNFGFunctions.c
@@ -35,7 +35,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 //TODO: Refactor to remove malloc reliance.
 #ifndef __clang__
-#include <malloc.h>
 #endif
 
 int CNFGPenX, CNFGPenY;

--- a/CNFGHTTP.c
+++ b/CNFGHTTP.c
@@ -20,7 +20,6 @@
 
 
 #include <stdint.h>
-#include <malloc.h>
 
 typedef struct {
     uint32_t state[5];

--- a/CNFGWinDriver.c
+++ b/CNFGWinDriver.c
@@ -7,7 +7,6 @@
 #include "CNFG.h"
 #include <windows.h>
 #include <stdlib.h>
-#include <malloc.h> //for alloca
 #include <ctype.h>
 
 HBITMAP CNFGlsBitmap;

--- a/CNFGXDriver.c
+++ b/CNFGXDriver.c
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 
 #ifdef HAS_XINERAMA
 	#include <X11/extensions/shape.h>

--- a/rawdraw_sf.h
+++ b/rawdraw_sf.h
@@ -3356,7 +3356,6 @@ void CNFGHandleInput()
 
 #include <windows.h>
 #include <stdlib.h>
-//#include <malloc.h> //for alloca
 #include <ctype.h>
 
 HBITMAP CNFGlsBitmap;
@@ -5527,7 +5526,6 @@ void AndroidSendToBack( int param )
 
 #include <stdio.h>
 #include <stdlib.h>
-//#include <malloc.h>
 
 #ifdef HAS_XINERAMA
 	#include <X11/extensions/shape.h>
@@ -6510,7 +6508,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 //TODO: Refactor to remove malloc reliance.
 #ifndef __clang__
-//#include <malloc.h>
 #endif
 
 int CNFGPenX, CNFGPenY;

--- a/rawdraw_sf.h
+++ b/rawdraw_sf.h
@@ -763,7 +763,6 @@ static inline void DumpObjectClassProperties( jobject objToDump )
 
 
 #include <stdint.h>
-#include <malloc.h>
 
 typedef struct {
     uint32_t state[5];
@@ -3357,7 +3356,7 @@ void CNFGHandleInput()
 
 #include <windows.h>
 #include <stdlib.h>
-#include <malloc.h> //for alloca
+//#include <malloc.h> //for alloca
 #include <ctype.h>
 
 HBITMAP CNFGlsBitmap;
@@ -5528,7 +5527,7 @@ void AndroidSendToBack( int param )
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
+//#include <malloc.h>
 
 #ifdef HAS_XINERAMA
 	#include <X11/extensions/shape.h>
@@ -6511,7 +6510,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 //TODO: Refactor to remove malloc reliance.
 #ifndef __clang__
-#include <malloc.h>
+//#include <malloc.h>
 #endif
 
 int CNFGPenX, CNFGPenY;

--- a/rawdraw_sf.h
+++ b/rawdraw_sf.h
@@ -6506,10 +6506,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "TextTool/FontData.h"
 #endif
 
-//TODO: Refactor to remove malloc reliance.
-#ifndef __clang__
-#endif
-
 int CNFGPenX, CNFGPenY;
 uint32_t CNFGBGColor;
 uint32_t CNFGLastColor;


### PR DESCRIPTION
Removed references to malloc.h to resolve compilation errors when building on macOS