### PR TITLE
Fix CNFGHandleInput() return type mismatch

### DIFF
--- a/CNFGNullDriver.c
+++ b/CNFGNullDriver.c
@@ -30,8 +30,9 @@ int CNFGSetup( const char * WindowName, int sw, int sh )
 	return 0;
 }
 
-void CNFGHandleInput()
+int CNFGHandleInput()
 {
+	return 0;
 }
 
 

--- a/CNFGWASMDriver.c
+++ b/CNFGWASMDriver.c
@@ -75,10 +75,11 @@ void	CNFGSetLineWidth( short width )
 	//Rasterizer does not support line width.
 }
 
-void CNFGHandleInput()
+int CNFGHandleInput()
 {
 	//Do nothing.
 	//Input is handled on swap frame.
+	return 0;
 }
 
 #endif


### PR DESCRIPTION
Was poking at this to see if I could get it running on my ESP32 but the first stumbling block was a compile error arising from conflicting declarations of CNFGHandleInput(). 

I replaced the stub function implementations in the Null and WASM drivers with ones that returned an int (specifically, 0).