### PR TITLE
I added missing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ is as follows:
 
 
 //Make it so we don't need to include any other C files in our build.
-#define CNFG_IMPLEMENTATION
-
+#include <android_native_app_glue.h>
 #include "rawdraw_sf.h"
+#define CNFG_IMPLEMENTATION
 
 void HandleKey( int keycode, int bDown ) { }
 void HandleButton( int x, int y, int button, int bDown ) { }


### PR DESCRIPTION
without
#include <android_native_app_glue.h>
library,
i was taking incomplete definitions code error
see: https://github.com/cntools/rawdraw/issues/113

after reverse engineering (i added and deleted many libraries and ordered to WSL 'make run' and as conclusion i discovered essential library is glue library), i found which library is missing

I still have another error, but it is fix of this error