### PR TITLE
Add missing malloc.h include

### DIFF
--- a/CNFGOGL.c
+++ b/CNFGOGL.c
@@ -10,6 +10,7 @@
 
 //Shader compilation errors go to stderr.
 #include <stdio.h>
+#include <malloc.h>
 
 #ifndef GL_VERTEX_SHADER
 #define GL_FRAGMENT_SHADER                0x8B30


### PR DESCRIPTION
[`CNFGOGL.c` uses `alloca` on line 235](https://github.com/cntools/rawdraw/blob/cb2c15cc9065c830560a76673c329329a148fbf3/CNFGOGL.c#L235), however does not import `malloc.h`, where that is defined. This causes issues in downstream applications like colorchord, where it [surfaces as a call to an undeclared function](https://github.com/cnlohr/colorchord/pull/137#issuecomment-5250882783). This PR just adds the missing include.